### PR TITLE
Add Undocumented GS registers to ps2.xml

### DIFF
--- a/ps2.xml
+++ b/ps2.xml
@@ -1307,24 +1307,9 @@
                             <bitRange>[15:8]</bitRange>
                         </field>
                         <field>
-                            <name>NFLD</name>
-                            <description>(Uses EXTBUF external digital in)</description>
+                            <name>ONES</name>
+                            <description>All set to one. Behaviour is undefined according to the GS users manual but advises to set them regardless, so likely related to a hardware bug.</description>
                             <bitRange>[16:16]</bitRange>
-                        </field>
-                        <field>
-                            <name>EXVWINS</name>
-                            <description>(Uses EXTBUF external digital in)</description>
-                            <bitRange>[41:32]</bitRange>
-                        </field>
-                        <field>
-                            <name>EXVWINE</name>
-                            <description>(Uses EXTBUF external digital in)</description>
-                            <bitRange>[51:42]</bitRange>
-                        </field>
-                        <field>
-                            <name>EVSYNCMD</name>
-                            <description>(Uses EXTBUF external digital in)</description>
-                            <bitRange>[60:52]</bitRange>
                         </field>
                     </fields>
                 </register>
@@ -1604,14 +1589,14 @@
 
                 <register>
                     <name>SRFSH</name>
-                    <description>DRAM refresh rate.</description>
+                    <description>GS DRAM refresh rate.</description>
                     <addressOffset>0x30</addressOffset>
                     <access>write-only</access>
 
                     <fields>
                         <field>
                             <name>RFSH</name>
-                            <description>DRAM refresh rate.</description>
+                            <description>GS DRAM refresh rate.</description>
                             <bitRange>[3:0]</bitRange>
                         </field>
                     </fields>
@@ -1766,12 +1751,12 @@
                         </field>
                         <field>
                             <name>MAGH</name>
-                            <description>Horizontal magnification. Magnification = factor -1 (0 = 1x, 1 = 2x, etc.)</description>
+                            <description>Horizontal magnification in VCKs. Magnification = factor -1 (0 = 1x, 1 = 2x, etc.)</description>
                             <bitRange>[24:23]</bitRange>
                         </field>
                         <field>
                             <name>MAGV</name>
-                            <description>Vertical magnification. Magnification = factor -1 (0 = 1x, 1 = 2x, etc.)</description>
+                            <description>Vertical magnification in scanlines. Magnification = factor -1 (0 = 1x, 1 = 2x, etc.)</description>
                             <bitRange>[38:27]</bitRange>
                         </field>
                         <field>
@@ -1932,17 +1917,17 @@
                     <fields>
                         <field>
                             <name>SX</name>
-                            <description>Upper left X position (VCK).</description>
+                            <description>Upper left X position (px).</description>
                             <bitRange>[11:0]</bitRange>
                         </field>
                         <field>
                             <name>SY</name>
-                            <description>Upper left Y position (VCK).</description>
+                            <description>Upper left Y position (px).</description>
                             <bitRange>[22:12]</bitRange>
                         </field>
                         <field>
                             <name>SMPH</name>
-                            <description>Horizontal sampling rate interval (VCK).</description>
+                            <description>Horizontal sampling rate interval (measured in scanlines).</description>
                             <bitRange>[26:23]</bitRange>
                         </field>
                         <field>
@@ -2040,7 +2025,7 @@
                                 </enumeratedValue>
                                 <enumeratedValue>
                                     <name>ENABLE</name>
-                                    <description>Clear old event and enable new eent.</description>
+                                    <description>Clear old event and enable new event.</description>
                                     <value>1</value>
                                 </enumeratedValue>
                             </enumeratedValues>
@@ -2344,7 +2329,7 @@
                         </field>
                         <field>
                             <name>ONES</name>
-                            <description>All set to one, unknown why.</description>
+                            <description>All set to one. Behaviour is undefined according to the GS users manual but advises to set them regardless, so likely related to a hardware bug.</description>
                             <bitRange>[14:13]</bitRange>
                             <access>read-only</access>
                         </field>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1324,7 +1324,7 @@
                         <field>
                             <name>EVSYNCMD</name>
                             <description>(Uses EXTBUF external digital in)</description>
-                            <bitRange>[64:52]</bitRange>
+                            <bitRange>[60:52]</bitRange>
                         </field>
                     </fields>
                 </register>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1601,6 +1601,21 @@
                         </field>
                     </fields>
                 </register>
+
+                <register>
+                    <name>SRFSH</name>
+                    <description>DRAM refresh rate.</description>
+                    <addressOffset>0x30</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>RFSH</name>
+                            <description>DRAM refresh rate.</description>
+                            <bitRange>[3:0]</bitRange>
+                        </field>
+                    </fields>
+                </register>
             </registers>
         </peripheral>
 

--- a/ps2.xml
+++ b/ps2.xml
@@ -1619,7 +1619,7 @@
 
                 <register>
                     <name>SYNCH1</name>
-                    <description>FIXME: Unknown description.</description>
+                    <description>Sync-related. Specific purpose unknown.</description>
                     <addressOffset>0x40</addressOffset>
                     <access>write-only</access>
 
@@ -1654,7 +1654,7 @@
 
                 <register>
                     <name>SYNCH2</name>
-                    <description>FIXME: Unknown description.</description>
+                    <description>Sync-related. Specific purpose unknown.</description>
                     <addressOffset>0x50</addressOffset>
                     <access>write-only</access>
 
@@ -1674,39 +1674,39 @@
 
                 <register>
                     <name>SYNCV</name>
-                    <description>FIXME: Unknown description.</description>
+                    <description>VSync-related interval timins (?)</description>
                     <addressOffset>0x60</addressOffset>
                     <access>write-only</access>
 
                     <fields>
                         <field>
                             <name>VFP</name>
-                            <description>Vertical front porch. Halflines with colour burst after video data.</description>
+                            <description>Vertical front porch interval. Halflines with colour burst after video data.</description>
                             <bitRange>[9:0]</bitRange>
                         </field>
                         <field>
                             <name>VFPE</name>
-                            <description>Halflines without colour burst after VFP.</description>
+                            <description>Vertical front porch interval end. Halflines without colour burst after VFP.</description>
                             <bitRange>[19:10]</bitRange>
                         </field>
                         <field>
                             <name>VBP</name>
-                            <description>Vertical back porch. Halflines with colour burst after VBPE.</description>
+                            <description>Vertical back porch interval. Halflines with colour burst after VBPE.</description>
                             <bitRange>[31:20]</bitRange>
                         </field>
                         <field>
                             <name>VBPE</name>
-                            <description>Halflines without colour burst after VS.</description>
+                            <description>Vertical back porch interval end. Halflines without colour burst after VS.</description>
                             <bitRange>[41:32]</bitRange>
                         </field>
                         <field>
                             <name>VDP</name>
-                            <description>Halflines with video data.</description>
+                            <description>Vertical differential phase. Halflines with video data.</description>
                             <bitRange>[42:42]</bitRange>
                         </field>
                         <field>
                             <name>VS</name>
-                            <description>Halflines with VSYNC.</description>
+                            <description>Vertical Synchronisation timing. Halflines with VSYNC.</description>
                             <bitRange>[63:53]</bitRange>
                         </field>
                     </fields>
@@ -1973,18 +1973,19 @@
                     <fields>
                         <field>
                             <name>WRITE</name>
+                            <!-- What is feedback write? -->
                             <description>Enable feedback write.</description>
                             <bitRange>[0:0]</bitRange>
 
                             <enumeratedValues>
                                 <enumeratedValue>
-                                    <name>COMPLETE_CURRENT</name>
-                                    <description>FIXME: Unknown description.</description>
+                                    <name>STOP</name>
+                                    <description>Complete current feedback write.</description>
                                     <value>0</value>
                                 </enumeratedValue>
                                 <enumeratedValue>
-                                    <name>START_NEXT</name>
-                                    <description>FIXME: Unknown description.</description>
+                                    <name>START</name>
+                                    <description>Start next feedback write.</description>
                                     <value>1</value>
                                 </enumeratedValue>
                             </enumeratedValues>
@@ -2348,7 +2349,7 @@
                         </field>
                         <field>
                             <name>ONES</name>
-                            <description>FIXME: Unknown description.</description>
+                            <description>All set to one, unknown why.</description>
                             <bitRange>[12:11]</bitRange>
                             <access>read-only</access>
                         </field>

--- a/ps2.xml
+++ b/ps2.xml
@@ -2018,6 +2018,82 @@
                     </fields>
                 </register>
             </registers>
+
+            <register>
+                <name>CSR</name>
+                <description>GS system status.</description>
+                <addressOffset>0x1000</addressOffset>
+                <access>read-write</access>
+
+                <fields>
+                    <field>
+                        <name>SIGNAL</name>
+                        <description>SIGNAL event control.</description>
+                        <bitRange>[0:0]</bitRange>
+                        </enumeratedValues>
+                    </field>
+                    <field>
+                        <name>FINISH</name>
+                        <description>SIGNAL event control.</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>
+                        <name>HSINT</name>
+                        <description>HSync interrupt control.</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>
+                        <name>VSINT</name>
+                        <description>VSync interrupt control.</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>
+                        <name>EDWINT</name>
+                        <description>Rectangular area write termination interrupt control.</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>
+                        <name>ZERO</name>
+                        <description>Must always be zero.</description>
+                        <bitRange>[6:5]</bitRange>
+                    </field>
+                    <field>
+                        <name>FLUSH</name>
+                        <description>Drawing suspend and FIFO clear (enabled during data write).</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>
+                        <name>RESET</name>
+                        <description>GS reset..</description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                    <field>
+                        <name>NFIELD</name>
+                        <description>VSync sampled FIELD.</description>
+                        <bitRange>[12:12]</bitRange>
+                    </field>
+                    <field>
+                        <name>FIELD</name>
+                        <description>.</description>
+                        <bitRange>[13:13]</bitRange>
+                    </field>
+                    <field>
+                        <name>FIFO</name>
+                        <description>SIGNAL event control.</description>
+                        <bitRange>[15:14]</bitRange>
+                    </field>
+                    <field>
+                        <name>REV</name>
+                        <description>SIGNAL event control.</description>
+                        <bitRange>[23:16]</bitRange>
+                    </field>
+                    <field>
+                        <name>ID</name>
+                        <description>SIGNAL event control.</description>
+                        <bitRange>[31:24]</bitRange>
+                    </field>
+                </fields>
+            </register>
         </peripheral>
 
         <peripheral>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1525,6 +1525,82 @@
                         <!-- Bits 37-63 are unused. -->
                     </fields>
                 </register>
+
+                <register>
+                    <name>SMODE2</name>
+                    <description>Video mode settings for synchronisation.</description>
+                    <addressOffset>0x20</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>INT</name>
+                            <description>Interlace mode.</description>
+                            <bitRange>[0:0]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>PROGRESSIVE</name>
+                                    <description>Progressive (noninterlace) mode.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>INTERLACE</name>
+                                    <description>Interlace mode.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+
+                        <field>
+                            <name>FFMD</name>
+                            <description>Field or Frame mode.</description>
+                            <bitRange>[1:1]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>FIELD</name>
+                                    <description>Field mode (every other line is read.)</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>FRAME</name>
+                                    <description>Frame mode (every line is read.)</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+
+                        <field>
+                            <name>DPMS</name>
+                            <description>VESA display power management signalling.</description>
+                            <bitRange>[3:2]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>ON</name>
+                                    <description>In use.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>STANDBY</name>
+                                    <description>Blanked, low power.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>SUSPEND</name>
+                                    <description>Blanked, lower power.</description>
+                                    <value>2</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>OFF</name>
+                                    <description>Shut off, awaiting activity.</description>
+                                    <value>3</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                    </fields>
+                </register>
             </registers>
         </peripheral>
 

--- a/ps2.xml
+++ b/ps2.xml
@@ -1403,11 +1403,6 @@
                         <field>
                             <name>SINT</name>
                             <description>UNKNOWN. Related to the Phase Lock Loop (PLL) circuit.</description>
-                            <bitRange>[16:16]</bitRange>
-                        </field>
-                        <field>
-                            <name>XPCK</name>
-                            <description>UNKNOWN.</description>
                             <bitRange>[17:17]</bitRange>
                         </field>
                         <field>

--- a/ps2.xml
+++ b/ps2.xml
@@ -2017,345 +2017,372 @@
                         </field>
                     </fields>
                 </register>
+
+                <register>
+                    <name>CSR</name>
+                    <description>GS system status and control registers.</description>
+                    <addressOffset>0x1000</addressOffset>
+                    <access>read-write</access>
+
+                    <fields>
+                        <field>
+                            <name>SIGNAL</name>
+                            <description>SIGNAL event control.</description>
+                            <bitRange>[0:0]</bitRange>
+
+                            <enumeratedValues>
+                                <usage>write</usage>
+                                <enumeratedValue>
+                                    <name>NO_ACTION</name>
+                                    <description>No action.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ENABLE</name>
+                                    <description>Clear old event and enable new eent.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+
+                            <enumeratedValues>
+                                <usage>read</usage>
+                                <enumeratedValue>
+                                    <name>NO_SIGNAL</name>
+                                    <description>No SIGNAL pending.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>SIGNAL_GENERATED</name>
+                                    <description>SIGNAL generated.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>FINISH</name>
+                            <description>FINISH event control.</description>
+                            <bitRange>[1:1]</bitRange>
+
+                            <enumeratedValues>
+                                <usage>write</usage>
+                                <enumeratedValue>
+                                    <name>NO_ACTION</name>
+                                    <description>No action.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ENABLE</name>
+                                    <description>FINISH event is enabled.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+
+                            <enumeratedValues>
+                                <usage>read</usage>
+                                <enumeratedValue>
+                                    <name>NO_FINISH</name>
+                                    <description>No FINISH pending.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>FINISH_GENERATED</name>
+                                    <description>FINISH generated.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>HSINT</name>
+                            <description>HSync interrupt control.</description>
+                            <bitRange>[2:2]</bitRange>
+
+                            <enumeratedValues>
+                                <usage>write</usage>
+                                <enumeratedValue>
+                                    <name>NO_ACTION</name>
+                                    <description>No action.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ENABLE</name>
+                                    <description>HSync interrupt is enabled.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+
+                            <enumeratedValues>
+                                <usage>read</usage>
+                                <enumeratedValue>
+                                    <name>NO_HSYNC.</name>
+                                    <description>No Hsync interrupt pending.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>HSYNC_GENERATED.</name>
+                                    <description>Hsync interrupt has been generated.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>VSINT</name>
+                            <description>VSync interrupt control.</description>
+                            <bitRange>[3:3]</bitRange>
+
+                            <enumeratedValues>
+                                <usage>write</usage>
+                                <enumeratedValue>
+                                    <name>NO_ACTION</name>
+                                    <description>No action.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ENABLE</name>
+                                    <description>VSync interrupt is enabled.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+
+                            <enumeratedValues>
+                                <usage>read</usage>
+                                <enumeratedValue>
+                                    <name>NO_VSYNC.</name>
+                                    <description>No Vsync interrupt pending.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>VSYNC_GENERATED.</name>
+                                    <description>Vsync interrupt has been generated.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>EDWINT</name>
+                            <description>Rectangular area write termination interrupt control.</description>
+                            <bitRange>[4:4]</bitRange>
+
+                            <enumeratedValues>
+                                <usage>write</usage>
+                                <enumeratedValue>
+                                    <name>NO_ACTION</name>
+                                    <description>No action.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ENABLE</name>
+                                    <description>Rectangular area write interrupt is enabled.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+
+                            <enumeratedValues>
+                                <usage>read</usage>
+                                <enumeratedValue>
+                                    <name>NO_HSYNC.</name>
+                                    <description>No rectangular area write interrupt pending.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>RAWRITE_GENERATED.</name>
+                                    <description>Rectangular area write interrupt has been generated.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>ZERO</name>
+                            <description>Must always be zero.</description>
+                            <bitRange>[6:5]</bitRange>
+
+                            <writeConstraint>
+                                <range>
+                                    <minimum>0</minimum>
+                                    <maximum>0</maximum>
+                                </range>
+                            </writeConstraint>
+                        </field>
+                        <field>
+                            <name>FLUSH</name>
+                            <description>Drawing suspend and FIFO clear (enabled during data write).</description>
+                            <bitRange>[8:8]</bitRange>
+                            <access>write-only</access>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>RESUME</name>
+                                    <description>Resume drawing if suspended (?)</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>FLUSH</name>
+                                    <description>Flush the GS FIFO and suspend drawing.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>RESET</name>
+                            <description>GS reset..</description>
+                            <bitRange>[9:9]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>DO_NOTHING</name>
+                                    <description>Do nothing.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>RESET</name>
+                                    <description>GS soft system reset. Clears FIFOs and resets IMR to all 1's.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>NFIELD</name>
+                            <description>VSync sampled FIELD.</description>
+                            <bitRange>[12:12]</bitRange>
+                        </field>
+                        <field>
+                            <name>FIELD</name>
+                            <description>Current Field of display [page-flipping].</description>
+                            <bitRange>[13:13]</bitRange>
+                            <access>read-only</access>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>EVEN</name>
+                                    <description>Even display buffer.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ODD</name>
+                                    <description>Odd display buffer.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>FIFO</name>
+                            <description>GS FIFO status.</description>
+                            <bitRange>[15:14]</bitRange>
+                            <access>read-only</access>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>BETWEEN</name>
+                                    <description>Not empty but not near-full.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>EMPTY</name>
+                                    <description>FIFO is empty.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ALMOST_FULL</name>
+                                    <description>Almost full.</description>
+                                    <value>2</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>UNUSED</name>
+                                    <description>Reserved.</description>
+                                    <value>3</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>REV</name>
+                            <description>GS revision number.</description>
+                            <bitRange>[23:16]</bitRange>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ID</name>
+                            <description>GS Id.</description>
+                            <bitRange>[31:24]</bitRange>
+                            <access>read-only</access>
+                        </field>
+                        <!-- Bits 32-63 are unused. -->
+                    </fields>
+                </register>
+
+                <register>
+                    <name>IMR</name>
+                    <description>Interrupt mask control.</description>
+                    <addressOffset>0x1010</addressOffset>
+                    <access>read-only</access>
+
+                    <fields>
+                        <!-- Bits 0-7 are unused. -->
+                        <field>
+                            <name>SIGMSK</name>
+                            <description>Signal event interrupt mask.</description>
+                            <bitRange>[8:8]</bitRange>
+                        </field>
+                        <field>
+                            <name>FINISHMSK</name>
+                            <description>Finish event interrupt mask.</description>
+                            <bitRange>[9:9]</bitRange>
+                        </field>
+                        <field>
+                            <name>HSMSK</name>
+                            <description>HSync interrupt mask.</description>
+                            <bitRange>[10:10]</bitRange>
+                        </field>
+                        <field>
+                            <name>VSMSK</name>
+                            <description>VSync interrupt mask.</description>
+                            <bitRange>[11:11]</bitRange>
+                        </field>
+                        <field>
+                            <name>EDWMSK</name>
+                            <description>Rectangle write termination interrupt mask.</description>
+                            <bitRange>[12:12]</bitRange>
+                        </field>
+                        <field>
+                            <name>HSMSK</name>
+                            <description>HSync interrupt mask.</description>
+                            <bitRange>[10:10]</bitRange>
+                        </field>
+                        <field>
+                            <name>ONES</name>
+                            <description>FIXME: Unknown description.</description>
+                            <bitRange>[12:11]</bitRange>
+                            <access>read-only</access>
+                        </field>
+                        <!-- Bits 13-63 are unused. -->
+                    </fields>
+                </register>
+
+                <register>
+                    <name>BUSDIR</name>
+                    <description>GS bus direction.</description>
+                    <addressOffset>0x1040</addressOffset>
+                    <access>read-only</access>
+
+                    <fields>
+                        <field>
+                            <name>DIR</name>
+                            <description>Host to local direction, or vice versa.</description>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>HOST_TO_LOCAL</name>
+                                    <description>Host to local bus transfer.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>LOCAL_TO_HOST</name>
+                                    <description>Local to host bus transfer.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                    </fields>
+                </register>
             </registers>
-
-            <register>
-                <name>CSR</name>
-                <description>GS system status and control registers.</description>
-                <addressOffset>0x1000</addressOffset>
-                <access>read-write</access>
-
-                <fields>
-                    <field>
-                        <name>SIGNAL</name>
-                        <description>SIGNAL event control.</description>
-                        <bitRange>[0:0]</bitRange>
-
-                        <enumeratedValues>
-                            <usage>write</usage>
-                            <enumeratedValue>
-                                <name>NO_ACTION</name>
-                                <description>No action.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>ENABLE</name>
-                                <description>Clear old event and enable new eent.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-
-                        <enumeratedValues>
-                            <usage>read</usage>
-                            <enumeratedValue>
-                                <name>NO_SIGNAL</name>
-                                <description>No SIGNAL pending.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>SIGNAL_GENERATED</name>
-                                <description>SIGNAL generated.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-                    </field>
-                    <field>
-                        <name>FINISH</name>
-                        <description>FINISH event control.</description>
-                        <bitRange>[1:1]</bitRange>
-
-                        <enumeratedValues>
-                            <usage>write</usage>
-                            <enumeratedValue>
-                                <name>NO_ACTION</name>
-                                <description>No action.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>ENABLE</name>
-                                <description>FINISH event is enabled.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-
-                        <enumeratedValues>
-                            <usage>read</usage>
-                            <enumeratedValue>
-                                <name>NO_FINISH</name>
-                                <description>No FINISH pending.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>FINISH_GENERATED</name>
-                                <description>FINISH generated.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-                    </field>
-                    <field>
-                        <name>HSINT</name>
-                        <description>HSync interrupt control.</description>
-                        <bitRange>[2:2]</bitRange>
-
-                        <enumeratedValues>
-                            <usage>write</usage>
-                            <enumeratedValue>
-                                <name>NO_ACTION</name>
-                                <description>No action.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>ENABLE</name>
-                                <description>HSync interrupt is enabled.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-
-                        <enumeratedValues>
-                            <usage>read</usage>
-                            <enumeratedValue>
-                                <name>NO_HSYNC.</name>
-                                <description>No Hsync interrupt pending.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>HSYNC_GENERATED.</name>
-                                <description>Hsync interrupt has been generated.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-                    </field>
-                    <field>
-                        <name>VSINT</name>
-                        <description>VSync interrupt control.</description>
-                        <bitRange>[3:3]</bitRange>
-
-                        <enumeratedValues>
-                            <usage>write</usage>
-                            <enumeratedValue>
-                                <name>NO_ACTION</name>
-                                <description>No action.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>ENABLE</name>
-                                <description>VSync interrupt is enabled.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-
-                        <enumeratedValues>
-                            <usage>read</usage>
-                            <enumeratedValue>
-                                <name>NO_VSYNC.</name>
-                                <description>No Vsync interrupt pending.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>VSYNC_GENERATED.</name>
-                                <description>Vsync interrupt has been generated.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-                    </field>
-                    <field>
-                        <name>EDWINT</name>
-                        <description>Rectangular area write termination interrupt control.</description>
-                        <bitRange>[4:4]</bitRange>
-
-                        <enumeratedValues>
-                            <usage>write</usage>
-                            <enumeratedValue>
-                                <name>NO_ACTION</name>
-                                <description>No action.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>ENABLE</name>
-                                <description>Rectangular area write interrupt is enabled.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-
-                        <enumeratedValues>
-                            <usage>read</usage>
-                            <enumeratedValue>
-                                <name>NO_HSYNC.</name>
-                                <description>No rectangular area write interrupt pending.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>RAWRITE_GENERATED.</name>
-                                <description>Rectangular area write interrupt has been generated.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-                    </field>
-                    <field>
-                        <name>ZERO</name>
-                        <description>Must always be zero.</description>
-                        <bitRange>[6:5]</bitRange>
-
-                        <writeConstraint>
-                            <range>
-                                <minimum>0</minimum>
-                                <maximum>0</maximum>
-                            </range>
-                        </writeConstraint>
-                    </field>
-                    <field>
-                        <name>FLUSH</name>
-                        <description>Drawing suspend and FIFO clear (enabled during data write).</description>
-                        <bitRange>[8:8]</bitRange>
-                        <access>write-only</access>
-
-                        <enumeratedValues>
-                            <enumeratedValue>
-                                <name>RESUME</name>
-                                <description>Resume drawing if suspended (?)</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>FLUSH</name>
-                                <description>Flush the GS FIFO and suspend drawing.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-                    </field>
-                    <field>
-                        <name>RESET</name>
-                        <description>GS reset..</description>
-                        <bitRange>[9:9]</bitRange>
-
-                        <enumeratedValues>
-                            <enumeratedValue>
-                                <name>DO_NOTHING</name>
-                                <description>Do nothing.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>RESET</name>
-                                <description>GS soft system reset. Clears FIFOs and resets IMR to all 1's.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-                    </field>
-                    <field>
-                        <name>NFIELD</name>
-                        <description>VSync sampled FIELD.</description>
-                        <bitRange>[12:12]</bitRange>
-                    </field>
-                    <field>
-                        <name>FIELD</name>
-                        <description>Current Field of display [page-flipping].</description>
-                        <bitRange>[13:13]</bitRange>
-                        <access>read-only</access>
-
-                        <enumeratedValues>
-                            <enumeratedValue>
-                                <name>EVEN</name>
-                                <description>Even display buffer.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>ODD</name>
-                                <description>Odd display buffer.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-                    </field>
-                    <field>
-                        <name>FIFO</name>
-                        <description>GS FIFO status.</description>
-                        <bitRange>[15:14]</bitRange>
-                        <access>read-only</access>
-
-                        <enumeratedValues>
-                            <enumeratedValue>
-                                <name>BETWEEN</name>
-                                <description>Not empty but not near-full.</description>
-                                <value>0</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>EMPTY</name>
-                                <description>FIFO is empty.</description>
-                                <value>1</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>ALMOST_FULL</name>
-                                <description>Almost full.</description>
-                                <value>2</value>
-                            </enumeratedValue>
-                            <enumeratedValue>
-                                <name>UNUSED</name>
-                                <description>Reserved.</description>
-                                <value>3</value>
-                            </enumeratedValue>
-                        </enumeratedValues>
-                    </field>
-                    <field>
-                        <name>REV</name>
-                        <description>GS revision number.</description>
-                        <bitRange>[23:16]</bitRange>
-                        <access>read-only</access>
-                    </field>
-                    <field>
-                        <name>ID</name>
-                        <description>GS Id.</description>
-                        <bitRange>[31:24]</bitRange>
-                        <access>read-only</access>
-                    </field>
-                    <!-- Bits 32-63 are unused. -->
-                </fields>
-            </register>
-
-            <register>
-                <name>IMR</name>
-                <description>Interrupt mask control.</description>
-                <addressOffset>0x1010</addressOffset>
-                <access>read-only</access>
-
-                <fields>
-                    <!-- Bits 0-7 are unused. -->
-                    <field>
-                        <name>SIGMSK</name>
-                        <description>Signal event interrupt mask.</description>
-                        <bitRange>[8:8]</bitRange>
-                    </field>
-                    <field>
-                        <name>FINISHMSK</name>
-                        <description>Finish event interrupt mask.</description>
-                        <bitRange>[9:9]</bitRange>
-                    </field>
-                    <field>
-                        <name>HSMSK</name>
-                        <description>HSync interrupt mask.</description>
-                        <bitRange>[10:10]</bitRange>
-                    </field>
-                    <field>
-                        <name>VSMSK</name>
-                        <description>VSync interrupt mask.</description>
-                        <bitRange>[11:11]</bitRange>
-                    </field>
-                    <field>
-                        <name>EDWMSK</name>
-                        <description>Rectangle write termination interrupt mask.</description>
-                        <bitRange>[12:12]</bitRange>
-                    </field>
-                    <field>
-                        <name>HSMSK</name>
-                        <description>HSync interrupt mask.</description>
-                        <bitRange>[10:10]</bitRange>
-                    </field>
-                    <field>
-                        <name>ONES</name>
-                        <description>FIXME: Unknown description.</description>
-                        <bitRange>[12:11]</bitRange>
-                        <access>read-only</access>
-                    </field>
-                    <!-- Bits 13-63 are unused. -->
-                </fields>
-            </register>
         </peripheral>
 
         <peripheral>

--- a/ps2.xml
+++ b/ps2.xml
@@ -2382,6 +2382,26 @@
                         </field>
                     </fields>
                 </register>
+
+                <register>
+                    <name>SIGLBLID</name>
+                    <description>Signal Id value.</description>
+                    <addressOffset>0x1080</addressOffset>
+                    <access>read-only</access>
+
+                    <fields>
+                        <field>
+                            <name>SIGID</name>
+                            <description>Id value set by SIGNAL register.</description>
+                            <bitRange>[31:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>LBLID</name>
+                            <description>Id value set by LABEL register.</description>
+                            <bitRange>[63:32]</bitRange>
+                        </field>
+                    </fields>
+                </register>
             </registers>
         </peripheral>
 

--- a/ps2.xml
+++ b/ps2.xml
@@ -1651,6 +1651,26 @@
                         </field>
                     </fields>
                 </register>
+
+                <register>
+                    <name>SYNCH2</name>
+                    <description>FIXME: Unknown description.</description>
+                    <addressOffset>0x50</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>HF</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[10:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>HB</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[21:11]</bitRange>
+                        </field>
+                    </fields>
+                </register>
             </registers>
         </peripheral>
 

--- a/ps2.xml
+++ b/ps2.xml
@@ -1671,6 +1671,46 @@
                         </field>
                     </fields>
                 </register>
+
+                <register>
+                    <name>SYNCV</name>
+                    <description>FIXME: Unknown description.</description>
+                    <addressOffset>0x60</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>VFP</name>
+                            <description>Vertical front porch. Halflines with colour burst after video data.</description>
+                            <bitRange>[9:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>VFPE</name>
+                            <description>Halflines without colour burst after VFP.</description>
+                            <bitRange>[19:10]</bitRange>
+                        </field>
+                        <field>
+                            <name>VBP</name>
+                            <description>Vertical back porch. Halflines with colour burst after VBPE.</description>
+                            <bitRange>[31:20]</bitRange>
+                        </field>
+                        <field>
+                            <name>VBPE</name>
+                            <description>Halflines without colour burst after VS.</description>
+                            <bitRange>[41:32]</bitRange>
+                        </field>
+                        <field>
+                            <name>VDP</name>
+                            <description>Halflines with video data.</description>
+                            <bitRange>[42:42]</bitRange>
+                        </field>
+                        <field>
+                            <name>VS</name>
+                            <description>Halflines with VSYNC.</description>
+                            <bitRange>[63:53]</bitRange>
+                        </field>
+                    </fields>
+                </register>
             </registers>
         </peripheral>
 

--- a/ps2.xml
+++ b/ps2.xml
@@ -1749,7 +1749,7 @@
 
                 <register>
                     <name>DISPLAY1</name>
-                    <description>FIXME: Unknown description.</description>
+                    <description>Rectangular viewport from output of Read Circuit 1.</description>
                     <addressOffset>0x80</addressOffset>
                     <access>write-only</access>
 
@@ -1793,10 +1793,134 @@
                     <addressOffset>0x90</addressOffset>
                 </register>
 
-                <register>
+                <register derivedFrom="DISPLAY1">
                     <name>DISPLAY2</name>
-                    <description>FIXME: Unknown description.</description>
+                    <description>Rectangular viewport from output of Read Circuit 1.</description>
                     <addressOffset>0xA0</addressOffset>
+                </register>
+
+                <register>
+                    <name>EXTBUF</name>
+                    <description>FIXME: Unknown description.</description>
+                    <addressOffset>0xB0</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>EXBP</name>
+                            <description>Buffer base pointer / 64.</description>
+                            <bitRange>[13:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>EXBW</name>
+                            <description>Width of buffer / 64.</description>
+                            <bitRange>[19:14]</bitRange>
+                        </field>
+                        <field>
+                            <name>FBIN</name>
+                            <description>Input source selection.</description>
+                            <bitRange>[21:20]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>OUT1</name>
+                                    <description>Output from Read Circuit 1.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>OUT2</name>
+                                    <description>Output from Read Circuit 2.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>WFFMD</name>
+                            <description>Interlace mode</description>
+                            <bitRange>[22:22]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>FIELD</name>
+                                    <description>Write to every other raster.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>FRAME</name>
+                                    <description>Write to every raster.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>EMODA</name>
+                            <description>Processing of input alpha.</description>
+                            <bitRange>[24:23]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>ALPHA</name>
+                                    <description>Write input alpha as-is from alpha channel.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>Y</name>
+                                    <description>Write input alpha as-is from Y colour channel.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>Y_HALF</name>
+                                    <description>Write input alpha as half of Y colour channel.</description>
+                                    <value>2</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ZERO</name>
+                                    <description>Alpha is fixed at zero.</description>
+                                    <value>3</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>EMODC</name>
+                            <description>Processing of input colour.</description>
+                            <bitRange>[26:25]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>RGB</name>
+                                    <description>Read colour from RGB channels.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>Y</name>
+                                    <description>Read colour as Y channel.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>YCBCR</name>
+                                    <description>Read color from YcBcR channels.</description>
+                                    <value>2</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ALPHA</name>
+                                    <description>Read color from alpha channel.</description>
+                                    <value>3</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+
+                        <!-- Bits 27-31 are unused. -->
+                        <field>
+                            <name>WDX</name>
+                            <description>Upper left X position.</description>
+                            <bitRange>[42:32]</bitRange>
+                        </field>
+                        <field>
+                            <name>WDY</name>
+                            <description>Upper left Y position.</description>
+                            <bitRange>[53:43]</bitRange>
+                        </field>
+                    </fields>
                 </register>
             </registers>
         </peripheral>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1195,45 +1195,117 @@
                     <name>PMODE</name>
                     <description>Various PCRTC controls. Accessible via EE.</description>
                     <addressOffset>0x00</addressOffset>
-                    <access>read-write</access>
+                    <access>write-only</access>
 
                     <fields>
                         <field>
                             <name>EN1</name>
-                            <description></description>
+                            <description>Enable / disable Read Circuit 1.</description>
                             <bitRange>[0:0]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>DISABLE</name>
+                                    <description>Disable Read Circuit 1.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ENABLE</name>
+                                    <description>Enable Read Circuit 1.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
                         </field>
                         <field>
                             <name>EN2</name>
-                            <description></description>
+                            <description>Enable / disable Read Circuit 2.</description>
                             <bitRange>[1:1]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>DISABLE</name>
+                                    <description>Disable Read Circuit 1.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ENABLE</name>
+                                    <description>Enable Read Circuit 1.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
                         </field>
                         <field>
                             <name>CRTMD</name>
-                            <description></description>
+                            <description>CRT output switching. Always set to 1.</description>
                             <bitRange>[4:2]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>DEFAULT</name>
+                                    <description>Only (known) valid value.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
                         </field>
                         <field>
                             <name>MMOD</name>
-                            <description></description>
+                            <description>Alpha blending value source.</description>
                             <bitRange>[5:5]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>BLEND_ALP</name>
+                                    <description>Get alpha from ALP field.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>BLEND_RC1</name>
+                                    <description>Get alpha from output of Read Circuit 1.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
                         </field>
                         <field>
                             <name>AMOD</name>
-                            <description></description>
+                            <description>OUT1 alpha output.</description>
                             <bitRange>[6:6]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>RC1</name>
+                                    <description>Alpha value from Read Circuit 1 for output selection.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ALPHA_FROM_RC2</name>
+                                    <description>Alpha value from Read Circuit 2 for output selection.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
                         </field>
                         <field>
                             <name>SLBG</name>
-                            <description></description>
+                            <description>Alpha blending method.</description>
                             <bitRange>[7:7]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>CIRCUIT2</name>
+                                    <description>Blend alpha with output of Read Circuit 2.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>BGCOLOR</name>
+                                    <description>Use background color.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
                         </field>
                         <field>
                             <name>ALP</name>
-                            <description>Alpha blending</description>
-                            <bitRange>[8:8]</bitRange>
+                            <description>Alpha blending value.</description>
+                            <bitRange>[15:8]</bitRange>
                         </field>
-                        <!-- Bits 9-15 are unused. -->
                         <field>
                             <name>NFLD</name>
                             <description></description>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1331,9 +1331,178 @@
 
                 <register>
                     <name>SMODE1</name>
-                    <description>Sync parameters for the PCRTC.</description>
+                    <description>Video signal settings. Sync parameters for the PCRTC.</description>
                     <addressOffset>0x10</addressOffset>
-                    <access>read-write</access>
+                    <access>write-only</access>
+
+                    <!-- Refer to https://github.com/jur/linux-2.2.1-ps2/blob/98cdeb6f28e401ef9ac3a750c1f8912ec7967681/drivers/video/ps2gs.c#L73 for reference values. -->
+                    <!-- To calculate video clock: video clock VCK = (13500000 * @lc) / ((@t1248 + 1) * @spml * @rc) -->
+                    <fields>
+                        <field>
+                            <name>RC</name>
+                            <description>Phase Lock Loop (PLL) reference divider.</description>
+                            <bitRange>[2:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>LC</name>
+                            <description>Phase Lock Loop (PLL) loop divider.</description>
+                            <bitRange>[9:3]</bitRange>
+                        </field>
+                        <field>
+                            <name>T128</name>
+                            <description>Phase Lock Loop (PLL) output divider.</description>
+                            <bitRange>[11:10]</bitRange>
+                        </field>
+                        <field>
+                            <name>SLCK</name>
+                            <description>UNKNOWN. Appears to always be set to 0.</description>
+                            <bitRange>[12:12]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>DEFAULT</name>
+                                    <description>Only ever seen set to 0.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>CMOD</name>
+                            <description>Subcarrier frequency (display mode.)</description>
+                            <bitRange>[14:13]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>VESA</name>
+                                    <description>Output a VESA signal.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <!-- Value 1 is reserved. -->
+                                <enumeratedValue>
+                                    <name>NTSC</name>
+                                    <description>Output an NTSC signal.</description>
+                                    <value>2</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>PAL</name>
+                                    <description>Output a PAL signal.</description>
+                                    <value>3</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>EX</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[15:15]</bitRange>
+                        </field>
+                        <field>
+                            <name>PRST</name>
+                            <description>Trigger a reset on the Phase Lock Loop (PLL) circuit.</description>
+                            <bitRange>[16:16]</bitRange>
+                        </field>
+                        <field>
+                            <name>SINT</name>
+                            <description>UNKNOWN. Related to the Phase Lock Loop (PLL) circuit.</description>
+                            <bitRange>[16:16]</bitRange>
+                        </field>
+                        <field>
+                            <name>XPCK</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[17:17]</bitRange>
+                        </field>
+                        <field>
+                            <name>XPCK</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[18:18]</bitRange>
+                        </field>
+                        <field>
+                            <name>PCK2</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[20:19]</bitRange>
+                        </field>
+                        <field>
+                            <name>SPML</name>
+                            <description>Sub-pixel magnification level.</description>
+                            <bitRange>[24:21]</bitRange>
+                        </field>
+                        <field>
+                            <name>GCONT</name>
+                            <description>Output colour format.</description>
+                            <bitRange>[25:25]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>RGBYC</name>
+                                    <description>RGBYc format.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>YCRCB</name>
+                                    <description>YCrCb format.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <field>
+                            <name>PHS</name>
+                            <description>UNKNOWN. Related to HSync output.</description>
+                            <bitRange>[26:26]</bitRange>
+                        </field>
+                        <field>
+                            <name>PVS</name>
+                            <description>UNKNOWN. Related to VSync output.</description>
+                            <bitRange>[27:27]</bitRange>
+                        </field>
+                        <field>
+                            <name>PEHS</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[28:28]</bitRange>
+                        </field>
+                        <field>
+                            <name>PEVS</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[29:29]</bitRange>
+                        </field>
+                        <field>
+                            <name>CLKSEL</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[31:30]</bitRange>
+                        </field>
+                        <field>
+                            <name>NVCK</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[32:32]</bitRange>
+                        </field>
+                        <field>
+                            <name>SLCK2</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[33:33]</bitRange>
+                        </field>
+                        <field>
+                            <name>VCKSEL</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[35:34]</bitRange>
+                        </field>
+                        <field>
+                            <name>VHP</name>
+                            <description>Scan mode.</description>
+                            <bitRange>[36:36]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>INTERLACED</name>
+                                    <description>Interlace mode.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>PROGRESSIVE</name>
+                                    <description>Progressive mode.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <!-- Bits 37-63 are unused. -->
+                    </fields>
                 </register>
             </registers>
         </peripheral>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1801,7 +1801,7 @@
 
                 <register>
                     <name>EXTBUF</name>
-                    <description>FIXME: Unknown description.</description>
+                    <description>Feedback write buffer.</description>
                     <addressOffset>0xB0</addressOffset>
                     <access>write-only</access>
 
@@ -1919,6 +1919,47 @@
                             <name>WDY</name>
                             <description>Upper left Y position.</description>
                             <bitRange>[53:43]</bitRange>
+                        </field>
+                    </fields>
+                </register>
+
+                <register>
+                    <name>EXTDATA</name>
+                    <description>Feedback write setting.</description>
+                    <addressOffset>0xC0</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>SX</name>
+                            <description>Upper left X position (VCK).</description>
+                            <bitRange>[11:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>SY</name>
+                            <description>Upper left Y position (VCK).</description>
+                            <bitRange>[22:12]</bitRange>
+                        </field>
+                        <field>
+                            <name>SMPH</name>
+                            <description>Horizontal sampling rate interval (VCK).</description>
+                            <bitRange>[26:23]</bitRange>
+                        </field>
+                        <field>
+                            <name>SMPV</name>
+                            <description>Vertical sampling rate interval (VCK).</description>
+                            <bitRange>[28:27]</bitRange>
+                        </field>
+                        <!-- Bits 29-31 are unused. -->
+                        <field>
+                            <name>WW</name>
+                            <description>Rectangular area width - 1.</description>
+                            <bitRange>[43:32]</bitRange>
+                        </field>
+                        <field>
+                            <name>WH</name>
+                            <description>Rectangular area height - 1.</description>
+                            <bitRange>[54:44]</bitRange>
                         </field>
                     </fields>
                 </register>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1224,12 +1224,12 @@
                             <enumeratedValues>
                                 <enumeratedValue>
                                     <name>DISABLE</name>
-                                    <description>Disable Read Circuit 1.</description>
+                                    <description>Disable Read Circuit 2.</description>
                                     <value>0</value>
                                 </enumeratedValue>
                                 <enumeratedValue>
                                     <name>ENABLE</name>
-                                    <description>Enable Read Circuit 1.</description>
+                                    <description>Enable Read Circuit 2.</description>
                                     <value>1</value>
                                 </enumeratedValue>
                             </enumeratedValues>
@@ -1241,7 +1241,7 @@
 
                             <enumeratedValues>
                                 <enumeratedValue>
-                                    <name>DEFAULT</name>
+                                    <name>OUT1</name>
                                     <description>Only (known) valid value.</description>
                                     <value>1</value>
                                 </enumeratedValue>
@@ -1267,7 +1267,7 @@
                         </field>
                         <field>
                             <name>AMOD</name>
-                            <description>OUT1 alpha output.</description>
+                            <description>Alpha source to CRTMD chosen output.</description>
                             <bitRange>[6:6]</bitRange>
 
                             <enumeratedValues>
@@ -1277,7 +1277,7 @@
                                     <value>0</value>
                                 </enumeratedValue>
                                 <enumeratedValue>
-                                    <name>ALPHA_FROM_RC2</name>
+                                    <name>RC2</name>
                                     <description>Alpha value from Read Circuit 2 for output selection.</description>
                                     <value>1</value>
                                 </enumeratedValue>
@@ -1308,22 +1308,22 @@
                         </field>
                         <field>
                             <name>NFLD</name>
-                            <description></description>
+                            <description>(Uses EXTBUF external digital in)</description>
                             <bitRange>[16:16]</bitRange>
                         </field>
                         <field>
                             <name>EXVWINS</name>
-                            <description></description>
+                            <description>(Uses EXTBUF external digital in)</description>
                             <bitRange>[41:32]</bitRange>
                         </field>
                         <field>
                             <name>EXVWINE</name>
-                            <description></description>
+                            <description>(Uses EXTBUF external digital in)</description>
                             <bitRange>[51:42]</bitRange>
                         </field>
                         <field>
                             <name>EVSYNCMD</name>
-                            <description></description>
+                            <description>(Uses EXTBUF external digital in)</description>
                             <bitRange>[64:52]</bitRange>
                         </field>
                     </fields>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1736,13 +1736,53 @@
                         </field>
                         <field>
                             <name>DBX</name>
-                            <description>Upper left x position.</description>
+                            <description>Upper left X position.</description>
                             <bitRange>[31:20]</bitRange>
                         </field>
                         <field>
                             <name>DBY</name>
-                            <description>Upper left y position.</description>
+                            <description>Upper left Y position.</description>
                             <bitRange>[43:32]</bitRange>
+                        </field>
+                    </fields>
+                </register>
+
+                <register>
+                    <name>DISPLAY1</name>
+                    <description>FIXME: Unknown description.</description>
+                    <addressOffset>0x80</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>DX</name>
+                            <description>Display X position (VCK).</description>
+                            <bitRange>[11:10]</bitRange>
+                        </field>
+                        <field>
+                            <name>DY</name>
+                            <description>Display Y position (px).</description>
+                            <bitRange>[22:12]</bitRange>
+                        </field>
+                        <field>
+                            <name>MAGH</name>
+                            <description>Horizontal magnification. Magnification = factor -1 (0 = 1x, 1 = 2x, etc.)</description>
+                            <bitRange>[24:23]</bitRange>
+                        </field>
+                        <field>
+                            <name>MAGV</name>
+                            <description>Vertical magnification. Magnification = factor -1 (0 = 1x, 1 = 2x, etc.)</description>
+                            <bitRange>[38:27]</bitRange>
+                        </field>
+                        <field>
+                            <name>DW</name>
+                            <description>Display area width - 1 (VCK).</description>
+                            <bitRange>[43:32]</bitRange>
+                        </field>
+                        <field>
+                            <name>DH</name>
+                            <description>Display area height - 1 (px).</description>
+                            <bitRange>[54:44]</bitRange>
                         </field>
                     </fields>
                 </register>
@@ -1751,6 +1791,12 @@
                     <name>DISPFB2</name>
                     <description>Framebuffer register for Output Circuit 2.</description>
                     <addressOffset>0x90</addressOffset>
+                </register>
+
+                <register>
+                    <name>DISPLAY2</name>
+                    <description>FIXME: Unknown description.</description>
+                    <addressOffset>0xA0</addressOffset>
                 </register>
             </registers>
         </peripheral>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1711,6 +1711,47 @@
                         </field>
                     </fields>
                 </register>
+
+                <register>
+                    <name>DISPFB1</name>
+                    <description>Framebuffer register for Output Circuit 1.</description>
+                    <addressOffset>0x70</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>FBP</name>
+                            <description>Base pointer address / 2048.</description>
+                            <bitRange>[8:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>FBW</name>
+                            <description>Buffer width / 64.</description>
+                            <bitRange>[14:9]</bitRange>
+                        </field>
+                        <field>
+                            <name>PSM</name>
+                            <description>Pixel storage format.</description>
+                            <bitRange>[19:15]</bitRange>
+                        </field>
+                        <field>
+                            <name>DBX</name>
+                            <description>Upper left x position.</description>
+                            <bitRange>[31:20]</bitRange>
+                        </field>
+                        <field>
+                            <name>DBY</name>
+                            <description>Upper left y position.</description>
+                            <bitRange>[43:32]</bitRange>
+                        </field>
+                    </fields>
+                </register>
+
+                <register derivedFrom="DISPFB1">
+                    <name>DISPFB2</name>
+                    <description>Framebuffer register for Output Circuit 2.</description>
+                    <addressOffset>0x90</addressOffset>
+                </register>
             </registers>
         </peripheral>
 

--- a/ps2.xml
+++ b/ps2.xml
@@ -1183,6 +1183,30 @@
         </peripheral>
 
         <peripheral>
+            <name>GS_PRIVILEGED</name>
+            <version>1</version>
+            <description>Privileged GS registers. These are accessed via mapped EE addressed, but the GIF is responsible for accessing the relevant registers on the GS.</description>
+            <groupName>GS_PRIVILEGED</groupName>
+            <baseAddress>0xB2000000</baseAddress>
+            <size>64</size>
+
+            <registers>
+                <register>
+                    <name>PMODE</name>
+                    <description>Various PCRTC controls.</description>
+                    <addressOffset>0x00</addressOffset>
+                </register>
+
+                <register>
+                    <name>SMODE1</name>
+                    <description>Sync parameters for the PCRTC.</description>
+                    <addressOffset>0x10</addressOffset>
+                    <access>read-write</access>
+                </register>
+            </registers>
+        </peripheral>
+
+        <peripheral>
             <name>VIF</name>
             <version>1</version>
             <description>VU Interface. See EE User's Manual, Chapter 6.</description>

--- a/ps2.xml
+++ b/ps2.xml
@@ -2021,7 +2021,7 @@
 
             <register>
                 <name>CSR</name>
-                <description>GS system status.</description>
+                <description>GS system status and control registers.</description>
                 <addressOffset>0x1000</addressOffset>
                 <access>read-write</access>
 
@@ -2030,42 +2030,215 @@
                         <name>SIGNAL</name>
                         <description>SIGNAL event control.</description>
                         <bitRange>[0:0]</bitRange>
+
+                        <enumeratedValues>
+                            <usage>write</usage>
+                            <enumeratedValue>
+                                <name>NO_ACTION</name>
+                                <description>No action.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ENABLE</name>
+                                <description>Clear old event and enable new eent.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+
+                        <enumeratedValues>
+                            <usage>read</usage>
+                            <enumeratedValue>
+                                <name>NO_SIGNAL</name>
+                                <description>No SIGNAL pending.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>SIGNAL_GENERATED</name>
+                                <description>SIGNAL generated.</description>
+                                <value>1</value>
+                            </enumeratedValue>
                         </enumeratedValues>
                     </field>
                     <field>
                         <name>FINISH</name>
-                        <description>SIGNAL event control.</description>
+                        <description>FINISH event control.</description>
                         <bitRange>[1:1]</bitRange>
+
+                        <enumeratedValues>
+                            <usage>write</usage>
+                            <enumeratedValue>
+                                <name>NO_ACTION</name>
+                                <description>No action.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ENABLE</name>
+                                <description>FINISH event is enabled.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+
+                        <enumeratedValues>
+                            <usage>read</usage>
+                            <enumeratedValue>
+                                <name>NO_FINISH</name>
+                                <description>No FINISH pending.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>FINISH_GENERATED</name>
+                                <description>FINISH generated.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
                     </field>
                     <field>
                         <name>HSINT</name>
                         <description>HSync interrupt control.</description>
                         <bitRange>[2:2]</bitRange>
+
+                        <enumeratedValues>
+                            <usage>write</usage>
+                            <enumeratedValue>
+                                <name>NO_ACTION</name>
+                                <description>No action.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ENABLE</name>
+                                <description>HSync interrupt is enabled.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+
+                        <enumeratedValues>
+                            <usage>read</usage>
+                            <enumeratedValue>
+                                <name>NO_HSYNC.</name>
+                                <description>No Hsync interrupt pending.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>HSYNC_GENERATED.</name>
+                                <description>Hsync interrupt has been generated.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
                     </field>
                     <field>
                         <name>VSINT</name>
                         <description>VSync interrupt control.</description>
                         <bitRange>[3:3]</bitRange>
+
+                        <enumeratedValues>
+                            <usage>write</usage>
+                            <enumeratedValue>
+                                <name>NO_ACTION</name>
+                                <description>No action.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ENABLE</name>
+                                <description>VSync interrupt is enabled.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+
+                        <enumeratedValues>
+                            <usage>read</usage>
+                            <enumeratedValue>
+                                <name>NO_VSYNC.</name>
+                                <description>No Vsync interrupt pending.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>VSYNC_GENERATED.</name>
+                                <description>Vsync interrupt has been generated.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
                     </field>
                     <field>
                         <name>EDWINT</name>
                         <description>Rectangular area write termination interrupt control.</description>
                         <bitRange>[4:4]</bitRange>
+
+                        <enumeratedValues>
+                            <usage>write</usage>
+                            <enumeratedValue>
+                                <name>NO_ACTION</name>
+                                <description>No action.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ENABLE</name>
+                                <description>Rectangular area write interrupt is enabled.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+
+                        <enumeratedValues>
+                            <usage>read</usage>
+                            <enumeratedValue>
+                                <name>NO_HSYNC.</name>
+                                <description>No rectangular area write interrupt pending.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>RAWRITE_GENERATED.</name>
+                                <description>Rectangular area write interrupt has been generated.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
                     </field>
                     <field>
                         <name>ZERO</name>
                         <description>Must always be zero.</description>
                         <bitRange>[6:5]</bitRange>
+
+                        <writeConstraint>
+                            <range>
+                                <minimum>0</minimum>
+                                <maximum>0</maximum>
+                            </range>
+                        </writeConstraint>
                     </field>
                     <field>
                         <name>FLUSH</name>
                         <description>Drawing suspend and FIFO clear (enabled during data write).</description>
                         <bitRange>[8:8]</bitRange>
+                        <access>write-only</access>
+
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>RESUME</name>
+                                <description>Resume drawing if suspended (?)</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>FLUSH</name>
+                                <description>Flush the GS FIFO and suspend drawing.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
                     </field>
                     <field>
                         <name>RESET</name>
                         <description>GS reset..</description>
                         <bitRange>[9:9]</bitRange>
+
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>DO_NOTHING</name>
+                                <description>Do nothing.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>RESET</name>
+                                <description>GS soft system reset. Clears FIFOs and resets IMR to all 1's.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
                     </field>
                     <field>
                         <name>NFIELD</name>
@@ -2074,23 +2247,63 @@
                     </field>
                     <field>
                         <name>FIELD</name>
-                        <description>.</description>
+                        <description>Current Field of display [page-flipping].</description>
                         <bitRange>[13:13]</bitRange>
+                        <access>read-only</access>
+
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>EVEN</name>
+                                <description>Even display buffer.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ODD</name>
+                                <description>Odd display buffer.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
                     </field>
                     <field>
                         <name>FIFO</name>
-                        <description>SIGNAL event control.</description>
+                        <description>GS FIFO status.</description>
                         <bitRange>[15:14]</bitRange>
+                        <access>read-only</access>
+
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>BETWEEN</name>
+                                <description>Not empty but not near-full.</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>EMPTY</name>
+                                <description>FIFO is empty.</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ALMOST_FULL</name>
+                                <description>Almost full.</description>
+                                <value>2</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>UNUSED</name>
+                                <description>Reserved.</description>
+                                <value>3</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
                     </field>
                     <field>
                         <name>REV</name>
-                        <description>SIGNAL event control.</description>
+                        <description>GS revision number.</description>
                         <bitRange>[23:16]</bitRange>
+                        <access>read-only</access>
                     </field>
                     <field>
                         <name>ID</name>
-                        <description>SIGNAL event control.</description>
+                        <description>GS Id.</description>
                         <bitRange>[31:24]</bitRange>
+                        <access>read-only</access>
                     </field>
                 </fields>
             </register>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1185,7 +1185,7 @@
         <peripheral>
             <name>GS_PRIVILEGED</name>
             <version>1</version>
-            <description>Privileged GS registers. These are accessed via mapped EE addressed, but the GIF is responsible for accessing the relevant registers on the GS.</description>
+            <description>Privileged GS registers. Some are accessible via mapped EE addressed, but some require the GIF for accessing the relevant registers on the GS.</description>
             <groupName>GS_PRIVILEGED</groupName>
             <baseAddress>0xB2000000</baseAddress>
             <size>64</size>
@@ -1193,8 +1193,68 @@
             <registers>
                 <register>
                     <name>PMODE</name>
-                    <description>Various PCRTC controls.</description>
+                    <description>Various PCRTC controls. Accessible via EE.</description>
                     <addressOffset>0x00</addressOffset>
+                    <access>read-write</access>
+
+                    <fields>
+                        <field>
+                            <name>EN1</name>
+                            <description></description>
+                            <bitRange>[0:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>EN2</name>
+                            <description></description>
+                            <bitRange>[1:1]</bitRange>
+                        </field>
+                        <field>
+                            <name>CRTMD</name>
+                            <description></description>
+                            <bitRange>[4:2]</bitRange>
+                        </field>
+                        <field>
+                            <name>MMOD</name>
+                            <description></description>
+                            <bitRange>[5:5]</bitRange>
+                        </field>
+                        <field>
+                            <name>AMOD</name>
+                            <description></description>
+                            <bitRange>[6:6]</bitRange>
+                        </field>
+                        <field>
+                            <name>SLBG</name>
+                            <description></description>
+                            <bitRange>[7:7]</bitRange>
+                        </field>
+                        <field>
+                            <name>ALP</name>
+                            <description>Alpha blending</description>
+                            <bitRange>[8:8]</bitRange>
+                        </field>
+                        <!-- Bits 9-15 are unused. -->
+                        <field>
+                            <name>NFLD</name>
+                            <description></description>
+                            <bitRange>[16:16]</bitRange>
+                        </field>
+                        <field>
+                            <name>EXVWINS</name>
+                            <description></description>
+                            <bitRange>[41:32]</bitRange>
+                        </field>
+                        <field>
+                            <name>EXVWINE</name>
+                            <description></description>
+                            <bitRange>[51:42]</bitRange>
+                        </field>
+                        <field>
+                            <name>EVSYNCMD</name>
+                            <description></description>
+                            <bitRange>[64:52]</bitRange>
+                        </field>
+                    </fields>
                 </register>
 
                 <register>

--- a/ps2.xml
+++ b/ps2.xml
@@ -2114,12 +2114,12 @@
                             <enumeratedValues>
                                 <usage>read</usage>
                                 <enumeratedValue>
-                                    <name>NO_HSYNC.</name>
+                                    <name>NO_HSYNC</name>
                                     <description>No Hsync interrupt pending.</description>
                                     <value>0</value>
                                 </enumeratedValue>
                                 <enumeratedValue>
-                                    <name>HSYNC_GENERATED.</name>
+                                    <name>HSYNC_GENERATED</name>
                                     <description>Hsync interrupt has been generated.</description>
                                     <value>1</value>
                                 </enumeratedValue>
@@ -2147,12 +2147,12 @@
                             <enumeratedValues>
                                 <usage>read</usage>
                                 <enumeratedValue>
-                                    <name>NO_VSYNC.</name>
+                                    <name>NO_VSYNC</name>
                                     <description>No Vsync interrupt pending.</description>
                                     <value>0</value>
                                 </enumeratedValue>
                                 <enumeratedValue>
-                                    <name>VSYNC_GENERATED.</name>
+                                    <name>VSYNC_GENERATED</name>
                                     <description>Vsync interrupt has been generated.</description>
                                     <value>1</value>
                                 </enumeratedValue>
@@ -2180,12 +2180,12 @@
                             <enumeratedValues>
                                 <usage>read</usage>
                                 <enumeratedValue>
-                                    <name>NO_HSYNC.</name>
+                                    <name>NO_EDWINT</name>
                                     <description>No rectangular area write interrupt pending.</description>
                                     <value>0</value>
                                 </enumeratedValue>
                                 <enumeratedValue>
-                                    <name>RAWRITE_GENERATED.</name>
+                                    <name>RAWRITE_GENERATED</name>
                                     <description>Rectangular area write interrupt has been generated.</description>
                                     <value>1</value>
                                 </enumeratedValue>
@@ -2343,14 +2343,9 @@
                             <bitRange>[12:12]</bitRange>
                         </field>
                         <field>
-                            <name>HSMSK</name>
-                            <description>HSync interrupt mask.</description>
-                            <bitRange>[10:10]</bitRange>
-                        </field>
-                        <field>
                             <name>ONES</name>
                             <description>All set to one, unknown why.</description>
-                            <bitRange>[12:11]</bitRange>
+                            <bitRange>[14:13]</bitRange>
                             <access>read-only</access>
                         </field>
                         <!-- Bits 13-63 are unused. -->
@@ -2367,6 +2362,7 @@
                         <field>
                             <name>DIR</name>
                             <description>Host to local direction, or vice versa.</description>
+                            <bitRange>[0:0]</bitRange>
 
                             <enumeratedValues>
                                 <enumeratedValue>

--- a/ps2.xml
+++ b/ps2.xml
@@ -2305,6 +2305,55 @@
                         <bitRange>[31:24]</bitRange>
                         <access>read-only</access>
                     </field>
+                    <!-- Bits 32-63 are unused. -->
+                </fields>
+            </register>
+
+            <register>
+                <name>IMR</name>
+                <description>Interrupt mask control.</description>
+                <addressOffset>0x1010</addressOffset>
+                <access>read-only</access>
+
+                <fields>
+                    <!-- Bits 0-7 are unused. -->
+                    <field>
+                        <name>SIGMSK</name>
+                        <description>Signal event interrupt mask.</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>
+                        <name>FINISHMSK</name>
+                        <description>Finish event interrupt mask.</description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                    <field>
+                        <name>HSMSK</name>
+                        <description>HSync interrupt mask.</description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>
+                        <name>VSMSK</name>
+                        <description>VSync interrupt mask.</description>
+                        <bitRange>[11:11]</bitRange>
+                    </field>
+                    <field>
+                        <name>EDWMSK</name>
+                        <description>Rectangle write termination interrupt mask.</description>
+                        <bitRange>[12:12]</bitRange>
+                    </field>
+                    <field>
+                        <name>HSMSK</name>
+                        <description>HSync interrupt mask.</description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>
+                        <name>ONES</name>
+                        <description>FIXME: Unknown description.</description>
+                        <bitRange>[12:11]</bitRange>
+                        <access>read-only</access>
+                    </field>
+                    <!-- Bits 13-63 are unused. -->
                 </fields>
             </register>
         </peripheral>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1992,6 +1992,31 @@
                         <!-- Bits 1-63 are unused. -->
                     </fields>
                 </register>
+
+                <register>
+                    <name>BGCOLOR</name>
+                    <description>Background colour.</description>
+                    <addressOffset>0xE0</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>R</name>
+                            <description>Red channel.</description>
+                            <bitRange>[7:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>G</name>
+                            <description>Green channel.</description>
+                            <bitRange>[15:8]</bitRange>
+                        </field>
+                        <field>
+                            <name>B</name>
+                            <description>Blue channel.</description>
+                            <bitRange>[23:16]</bitRange>
+                        </field>
+                    </fields>
+                </register>
             </registers>
         </peripheral>
 

--- a/ps2.xml
+++ b/ps2.xml
@@ -1397,13 +1397,39 @@
                         </field>
                         <field>
                             <name>PRST</name>
-                            <description>Trigger a reset on the Phase Lock Loop (PLL) circuit.</description>
+                            <description>Reset the PCRTC circuit. A special procedure should be followed to use properly (see GS Mode Selector app documentation.)</description>
                             <bitRange>[16:16]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>NOTHING</name>
+                                    <description>(Initial value) Does not trigger a reset.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>RESET</name>
+                                    <description>Trigger a reset.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
                         </field>
                         <field>
                             <name>SINT</name>
-                            <description>UNKNOWN. Related to the Phase Lock Loop (PLL) circuit.</description>
+                            <description>Activate / Deactivate the Phase Lock Loop (PLL) circuit. A special procedure should be followed to use properly (see GS Mode Selector app documentation.)</description>
                             <bitRange>[17:17]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>OFF</name>
+                                    <description>Turn off the PLL.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>ON</name>
+                                    <description>Turn on the PLL.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
                         </field>
                         <field>
                             <name>XPCK</name>

--- a/ps2.xml
+++ b/ps2.xml
@@ -1963,6 +1963,35 @@
                         </field>
                     </fields>
                 </register>
+
+                <register>
+                    <name>EXTWRITE</name>
+                    <description>Feedback write function control.</description>
+                    <addressOffset>0xD0</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>WRITE</name>
+                            <description>Enable feedback write.</description>
+                            <bitRange>[0:0]</bitRange>
+
+                            <enumeratedValues>
+                                <enumeratedValue>
+                                    <name>COMPLETE_CURRENT</name>
+                                    <description>FIXME: Unknown description.</description>
+                                    <value>0</value>
+                                </enumeratedValue>
+                                <enumeratedValue>
+                                    <name>START_NEXT</name>
+                                    <description>FIXME: Unknown description.</description>
+                                    <value>1</value>
+                                </enumeratedValue>
+                            </enumeratedValues>
+                        </field>
+                        <!-- Bits 1-63 are unused. -->
+                    </fields>
+                </register>
             </registers>
         </peripheral>
 

--- a/ps2.xml
+++ b/ps2.xml
@@ -1616,6 +1616,41 @@
                         </field>
                     </fields>
                 </register>
+
+                <register>
+                    <name>SYNCH1</name>
+                    <description>FIXME: Unknown description.</description>
+                    <addressOffset>0x40</addressOffset>
+                    <access>write-only</access>
+
+                    <fields>
+                        <field>
+                            <name>HFP</name>
+                            <description>Horizonal front porch.</description>
+                            <bitRange>[10:0]</bitRange>
+                        </field>
+                        <field>
+                            <name>HBP</name>
+                            <description>Horizonal back porch.</description>
+                            <bitRange>[21:11]</bitRange>
+                        </field>
+                        <field>
+                            <name>HSEQ</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[31:22]</bitRange>
+                        </field>
+                        <field>
+                            <name>HSVS</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[42:32]</bitRange>
+                        </field>
+                        <field>
+                            <name>HS</name>
+                            <description>UNKNOWN.</description>
+                            <bitRange>[63:43]</bitRange>
+                        </field>
+                    </fields>
+                </register>
             </registers>
         </peripheral>
 


### PR DESCRIPTION
Addresses issue #13.

* Add undocumented GS registers to the SVD file.
* Since they do not _directly_* use the GIF, they are included in a separate peripheral.

*The registers are accessed using the `LD/SD` instructions according to the EE user's manual.