### PR TITLE
Add CoP0 exception registers

### DIFF
--- a/hello-rs/src/main.rs
+++ b/hello-rs/src/main.rs
@@ -3,41 +3,10 @@
 
 extern crate panic_halt;
 extern crate prussia_bios as bios;
-extern crate prussia_debug as debug;
 extern crate prussia_dma as dma;
 extern crate prussia_rt as rt;
 
-use core::fmt::Write;
-
-use debug::EEOut;
-use rt::cop0::{BadVAddr, TimerCount};
-
 #[no_mangle]
 fn main() -> ! {
-    writeln!(EEOut, "Testing testing 123.").unwrap();
-
-    let bad_v_addr = BadVAddr::load();
-
-    writeln!(EEOut, "Received this bad address: {bad_v_addr:?}").unwrap();
-
-    let timer_count = TimerCount::working_load();
-    let other_timer_count = TimerCount::working_load();
-
-    writeln!(EEOut, "Received this TimerCount: {timer_count:?}").unwrap();
-
-    let yet_other_timer_count = TimerCount::failing_load();
-
-    writeln!(EEOut, "Received this TimerCount: {yet_other_timer_count:?}").unwrap();
-
-    let also_other_timer_count = TimerCount::working_load();
-
-    writeln!(
-        EEOut,
-        "Received this TimerCount: {also_other_timer_count:?}"
-    )
-    .unwrap();
-
-    loop {}
-
     bios::exit(0);
 }

--- a/hello-rs/src/main.rs
+++ b/hello-rs/src/main.rs
@@ -3,10 +3,41 @@
 
 extern crate panic_halt;
 extern crate prussia_bios as bios;
+extern crate prussia_debug as debug;
 extern crate prussia_dma as dma;
 extern crate prussia_rt as rt;
 
+use core::fmt::Write;
+
+use debug::EEOut;
+use rt::cop0::{BadVAddr, TimerCount};
+
 #[no_mangle]
 fn main() -> ! {
+    writeln!(EEOut, "Testing testing 123.").unwrap();
+
+    let bad_v_addr = BadVAddr::load();
+
+    writeln!(EEOut, "Received this bad address: {bad_v_addr:?}").unwrap();
+
+    let timer_count = TimerCount::working_load();
+    let other_timer_count = TimerCount::working_load();
+
+    writeln!(EEOut, "Received this TimerCount: {timer_count:?}").unwrap();
+
+    let yet_other_timer_count = TimerCount::failing_load();
+
+    writeln!(EEOut, "Received this TimerCount: {yet_other_timer_count:?}").unwrap();
+
+    let also_other_timer_count = TimerCount::working_load();
+
+    writeln!(
+        EEOut,
+        "Received this TimerCount: {also_other_timer_count:?}"
+    )
+    .unwrap();
+
+    loop {}
+
     bios::exit(0);
 }

--- a/prussia_rt/.gitignore
+++ b/prussia_rt/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 Cargo.lock
+
+asm-obj/

--- a/prussia_rt/build.rs
+++ b/prussia_rt/build.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let libprussia_rt_asm_src_path =
         PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?).join(LIBPRUSSIA_RT_ASM_SRC_NAME);
     println!(
-        "cargo::rerun-if-changed={}",
+        "cargo:rerun-if-changed={}",
         libprussia_rt_asm_src_path.display()
     );
 

--- a/prussia_rt/build.rs
+++ b/prussia_rt/build.rs
@@ -4,7 +4,11 @@ use std::{
     fs::{self, File},
     io::Write,
     path::PathBuf,
+    process::Command,
 };
+
+const LIBPRUSSIA_RT_ASM_SRC_NAME: &str = "src/routines.S";
+const LIBPRUSSIA_RT_ASM_LIB_NAME: &str = "libprussia-rt.a";
 
 fn main() -> Result<(), Box<dyn Error>> {
     // build directory for this crate
@@ -13,11 +17,35 @@ fn main() -> Result<(), Box<dyn Error>> {
     // extend the library search path
     println!("cargo:rustc-link-search={}", out_dir.display());
 
+    let libprussia_rt_asm_script_path =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?).join("rebuild-asm-lib.sh");
+
     // put `linkfile.ld` in the build directory
     File::create(out_dir.join("linkfile.ld"))?.write_all(include_bytes!("user-linkfile.ld"))?;
 
+    // Rebuild if routines.S has changed.
+    let libprussia_rt_asm_src_path =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?).join(LIBPRUSSIA_RT_ASM_SRC_NAME);
+    println!(
+        "cargo::rerun-if-changed={}",
+        libprussia_rt_asm_src_path.display()
+    );
+
+    // Run the routines.S rebuild script.
+    match Command::new(libprussia_rt_asm_script_path).status() {
+        Ok(e) => {
+            println!("rebuild-asm-lib.sh exit status: {e}");
+        }
+        Err(e) => {
+            return Err(Box::new(e));
+        }
+    }
+
     // and put `libprussia-rt.a` in there too
-    fs::copy("libprussia-rt.a", out_dir.join("libprussia-rt.a"))?;
+    fs::copy(
+        LIBPRUSSIA_RT_ASM_LIB_NAME,
+        out_dir.join(LIBPRUSSIA_RT_ASM_LIB_NAME),
+    )?;
     println!("cargo:rustc-link-lib=static=prussia-rt");
 
     Ok(())

--- a/prussia_rt/src/cop0.rs
+++ b/prussia_rt/src/cop0.rs
@@ -188,7 +188,7 @@ impl PerfCounterControl {
 /// Represents the CTR0 event Ids supported by the PCCR.EVENT0 register field.
 #[derive(Debug)]
 #[repr(u8)]
-pub enum PCCRCtr0 {
+pub enum PCCREvent0 {
     /// Reserved
     Reserved = 0,
     /// Processor cycle
@@ -225,15 +225,15 @@ pub enum PCCRCtr0 {
     NoEvent = 16,
 }
 
-impl From<PCCRCtr0> for PerfCounterControl {
-    fn from(value: PCCRCtr0) -> Self {
+impl From<PCCREvent0> for PerfCounterControl {
+    fn from(value: PCCREvent0) -> Self {
         let event0 = (value as u32) << 5;
 
         PerfCounterControl::from_bits_truncate(event0)
     }
 }
 
-impl From<PerfCounterControl> for PCCRCtr0 {
+impl From<PerfCounterControl> for PCCREvent0 {
     fn from(value: PerfCounterControl) -> Self {
         let bits: u32 = (value & PerfCounterControl::EVENT0).bits >> 5;
 
@@ -254,8 +254,9 @@ impl From<PerfCounterControl> for PCCRCtr0 {
             13 => Self::CompletesNonBdsInstruction,
             14 => Self::CompletesCop2Instruction,
             15 => Self::CompletesLoads,
-            _ => Self::NoEvent,
+            16 => Self::NoEvent,
             i if i > 16 && i < 32 => Self::Reserved,
+            _ => Self::NoEvent,
         }
     }
 }
@@ -263,7 +264,7 @@ impl From<PerfCounterControl> for PCCRCtr0 {
 /// Represents the CTR1 event Ids supported by the PCCR.EVENT1 register field.
 #[derive(Debug)]
 #[repr(u8)]
-pub enum PCCRCtr1 {
+pub enum PCCREvent1 {
     /// Issues low order branch
     IssuesLowOrderBranch = 0,
     /// Processor cycle
@@ -302,15 +303,15 @@ pub enum PCCRCtr1 {
     Reserved = 17,
 }
 
-impl From<PCCRCtr1> for PerfCounterControl {
-    fn from(value: PCCRCtr1) -> Self {
+impl From<PCCREvent1> for PerfCounterControl {
+    fn from(value: PCCREvent1) -> Self {
         let event1 = (value as u32) << 15;
 
         PerfCounterControl::from_bits_truncate(event1)
     }
 }
 
-impl From<PerfCounterControl> for PCCRCtr1 {
+impl From<PerfCounterControl> for PCCREvent1 {
     fn from(value: PerfCounterControl) -> Self {
         let bits: u32 = (value & PerfCounterControl::EVENT0).bits >> 5;
 
@@ -331,8 +332,9 @@ impl From<PerfCounterControl> for PCCRCtr1 {
             13 => Self::CompletesNonBdsInstruction,
             14 => Self::CompletesCop1Instruction,
             15 => Self::CompletesStores,
-            _ => Self::NoEvent,
+            16 => Self::NoEvent,
             i if i > 16 && i < 32 => Self::Reserved,
+            _ => Self::NoEvent,
         }
     }
 }

--- a/prussia_rt/src/cop0.rs
+++ b/prussia_rt/src/cop0.rs
@@ -10,6 +10,8 @@ extern "C" {
     fn _write_timercount(count: u32);
     fn _read_compare() -> u32;
     fn _write_compare(compare: u32);
+    fn _read_epc() -> u32;
+    fn _write_epc(epc: u32);
 }
 
 /// A virtual address responsible for either of the below exceptions:
@@ -108,6 +110,25 @@ impl Compare {
     /// Write [Self] to the _CoP0.Compare_ register (`$11`).
     pub fn store(self) {
         unsafe { _write_compare(self.0) }
+    }
+}
+
+/// A value read from the CoP0.EPC register. The value is the returning virtual address to jump to
+/// after handling an exception.
+#[derive(Debug)]
+pub struct EPC(u32);
+
+impl EPC {
+    /// Load an [EPC] value from the _CoP0.EPC_ register (`$14`).
+    pub fn load() -> Self {
+        let epc = unsafe { _read_epc() };
+
+        EPC(epc)
+    }
+
+    /// Write [Self] to the _CoP0.EPC_ register (`$14`).
+    pub fn store(self) {
+        unsafe { _write_epc(self.0) }
     }
 }
 

--- a/prussia_rt/src/cop0.rs
+++ b/prussia_rt/src/cop0.rs
@@ -8,6 +8,8 @@ extern "C" {
     fn _read_badvaddr() -> u32;
     fn _read_timercount() -> u32;
     fn _write_timercount(count: u32);
+    fn _read_compare() -> u32;
+    fn _write_compare(compare: u32);
 }
 
 /// A virtual address responsible for either of the below exceptions:
@@ -77,15 +79,7 @@ pub struct TimerCount(u32);
 
 impl TimerCount {
     /// Load a [TimerCount] value from the _CoP0.Count_ register (`$9`).
-    pub fn working_load() -> Self {
-        let count;
-        unsafe { asm!(".set noat; mfc0 {}, $9", out(reg) count) };
-
-        TimerCount(count)
-    }
-
-    /// Load a [TimerCount] value from the _CoP0.Count_ register (`$9`).
-    pub fn failing_load() -> Self {
+    pub fn load() -> Self {
         let count = unsafe { _read_timercount() };
 
         TimerCount(count)
@@ -97,7 +91,26 @@ impl TimerCount {
     }
 }
 
-// TODO: Compare
+/// A value read from the CoP0.Compare register. The register acts as a timer;
+/// when the Count register becomes equal to the Compare register, the interrupt bit in the Cause
+/// register is set, and a timer interrupt occurs if enabled.
+#[derive(Debug)]
+pub struct Compare(u32);
+
+impl Compare {
+    /// Load a [Compare] value from the _CoP0.Compare_ register (`$11`).
+    pub fn load() -> Self {
+        let compare = unsafe { _read_compare() };
+
+        Compare(compare)
+    }
+
+    /// Write [Self] to the _CoP0.Compare_ register (`$11`).
+    pub fn store(self) {
+        unsafe { _write_compare(self.0) }
+    }
+}
+
 // TODO: EPC
 // TODO: BadPAddr
 // TODO: Perf

--- a/prussia_rt/src/cop0.rs
+++ b/prussia_rt/src/cop0.rs
@@ -181,6 +181,158 @@ impl PerfCounterControl {
     }
 }
 
+/// Represents the CTR0 event Ids supported by the PCCR.EVENT0 register field.
+#[derive(Debug)]
+#[repr(u8)]
+pub enum PCCRCtr0 {
+    /// Reserved
+    Reserved = 0,
+    /// Processor cycle
+    ProcessorCycle = 1,
+    /// Issues single instruction
+    IssueSingleInstruction = 2,
+    /// Issues branch
+    IssuesBranch = 3,
+    /// BTAC miss
+    BtacMiss = 4,
+    /// TLB miss
+    TlbMiss = 5,
+    /// Instruction cache miss
+    InstructionCacheMiss = 6,
+    /// Access DTLB
+    AccessDtlb = 7,
+    /// Non-blocking load
+    NonBlockingLoad = 8,
+    /// WBB single request
+    WBBSingleRequest = 9,
+    /// WBB burst request
+    WBBBurstRequest = 10,
+    /// CPU address bus busy
+    CPUAddressBusBusy = 11,
+    /// Completes instruction
+    CompletesInstruction = 12,
+    /// Completes non-BDS instruction
+    CompletesNonBdsInstruction = 13,
+    /// Completes COP2 instruction
+    CompletesCop2Instruction = 14,
+    /// Completes load
+    CompletesLoads = 15,
+    /// No event
+    NoEvent = 16,
+}
+
+impl From<PCCRCtr0> for PerfCounterControl {
+    fn from(value: PCCRCtr0) -> Self {
+        let event0 = (value as u32) << 5;
+
+        PerfCounterControl::from_bits_truncate(event0)
+    }
+}
+
+impl From<PerfCounterControl> for PCCRCtr0 {
+    fn from(value: PerfCounterControl) -> Self {
+        let bits: u32 = (value & PerfCounterControl::EVENT0).bits >> 5;
+
+        match bits {
+            0 => Self::Reserved,
+            1 => Self::ProcessorCycle,
+            2 => Self::IssueSingleInstruction,
+            3 => Self::IssuesBranch,
+            4 => Self::BtacMiss,
+            5 => Self::TlbMiss,
+            6 => Self::InstructionCacheMiss,
+            7 => Self::AccessDtlb,
+            8 => Self::NonBlockingLoad,
+            9 => Self::WBBSingleRequest,
+            10 => Self::WBBBurstRequest,
+            11 => Self::CPUAddressBusBusy,
+            12 => Self::CompletesInstruction,
+            13 => Self::CompletesNonBdsInstruction,
+            14 => Self::CompletesCop2Instruction,
+            15 => Self::CompletesLoads,
+            _ => Self::NoEvent,
+            i if i > 16 && i < 32 => Self::Reserved,
+        }
+    }
+}
+
+/// Represents the CTR1 event Ids supported by the PCCR.EVENT1 register field.
+#[derive(Debug)]
+#[repr(u8)]
+pub enum PCCRCtr1 {
+    /// Issues low order branch
+    IssuesLowOrderBranch = 0,
+    /// Processor cycle
+    ProcessorCycle = 1,
+    /// Issues double instruction
+    IssuesDoubleInstruction = 2,
+    /// Branch prediction miss
+    BranchPredictionMiss = 3,
+    /// TLB miss
+    TlbMiss = 4,
+    /// DTLB miss
+    DtlbMiss = 5,
+    /// Data cache miss
+    DataCacheMiss = 6,
+    /// WBB single request unusable
+    WbbSingleRequestUnusable = 7,
+    /// WBB burst request unusable
+    WbbBurstRequestUnusable = 8,
+    /// WBB burst request almost full
+    WbbBurstRequestAlmostFull = 9,
+    /// WBB burst request full
+    WbbBurstRequestFull = 10,
+    /// CPU data bus busy
+    CpuDataBusBusy = 11,
+    /// Completes instruction
+    CompletesInstruction = 12,
+    /// Completes non-BDS instruction
+    CompletesNonBdsInstruction = 13,
+    /// Completes COP1 instruction
+    CompletesCop1Instruction = 14,
+    /// Completes stores
+    CompletesStores = 15,
+    /// No event
+    NoEvent = 16,
+    /// Reserved
+    Reserved = 17,
+}
+
+impl From<PCCRCtr1> for PerfCounterControl {
+    fn from(value: PCCRCtr1) -> Self {
+        let event1 = (value as u32) << 15;
+
+        PerfCounterControl::from_bits_truncate(event1)
+    }
+}
+
+impl From<PerfCounterControl> for PCCRCtr1 {
+    fn from(value: PerfCounterControl) -> Self {
+        let bits: u32 = (value & PerfCounterControl::EVENT0).bits >> 5;
+
+        match bits {
+            0 => Self::IssuesLowOrderBranch,
+            1 => Self::ProcessorCycle,
+            2 => Self::IssuesDoubleInstruction,
+            3 => Self::BranchPredictionMiss,
+            4 => Self::TlbMiss,
+            5 => Self::DtlbMiss,
+            6 => Self::DataCacheMiss,
+            7 => Self::WbbSingleRequestUnusable,
+            8 => Self::WbbBurstRequestUnusable,
+            9 => Self::WbbBurstRequestAlmostFull,
+            10 => Self::WbbBurstRequestFull,
+            11 => Self::CpuDataBusBusy,
+            12 => Self::CompletesInstruction,
+            13 => Self::CompletesNonBdsInstruction,
+            14 => Self::CompletesCop1Instruction,
+            15 => Self::CompletesStores,
+            _ => Self::NoEvent,
+            i if i > 16 && i < 32 => Self::Reserved,
+        }
+    }
+}
+
 // TODO: Perf
 
 bitflags! {

--- a/prussia_rt/src/cop0.rs
+++ b/prussia_rt/src/cop0.rs
@@ -12,6 +12,8 @@ extern "C" {
     fn _write_compare(compare: u32);
     fn _read_epc() -> u32;
     fn _write_epc(epc: u32);
+    fn _read_badpaddr() -> u32;
+    fn _write_badpaddr(badpaddr: u32);
 }
 
 /// A virtual address responsible for either of the below exceptions:
@@ -132,7 +134,25 @@ impl EPC {
     }
 }
 
-// TODO: EPC
+/// A physical address read from teh CoP0.BadPAddr register. The value is automatically set to the
+/// most recent physical address that caused a bus error (assuming bus error masking (Status.BEM) is disabled).
+#[derive(Debug)]
+pub struct BadPAddr(u32);
+
+impl BadPAddr {
+    /// Load a [BadPAddr] value from the _CoP0.BadPAddr_ register (`$23`).
+    pub fn load() -> Self {
+        let badpaddr = unsafe { _read_badpaddr() };
+
+        BadPAddr(badpaddr)
+    }
+
+    /// Write [Self] to the _CoP0.BadPAddr_ register (`$23`).
+    pub fn store(self) {
+        unsafe { _write_badpaddr(self.0) }
+    }
+}
+
 // TODO: BadPAddr
 // TODO: Perf
 // TODO: ErrorEPC

--- a/prussia_rt/src/cop0.rs
+++ b/prussia_rt/src/cop0.rs
@@ -1,8 +1,31 @@
 //! Coprocessor 0 manipulation routines.
 
-use core::arch::asm;
+use core::arch::{asm, global_asm};
 
 use bitflags::bitflags;
+
+// global_asm!(include_str!("routines.S"));
+
+extern "C" {
+    fn _read_badvaddr() -> u32;
+}
+
+/// A virtual address responsible for either of the below exceptions:
+/// * TLB Invalid
+/// * TLB Modified
+/// * TLB Refill
+/// * Address Error
+#[derive(Debug)]
+pub struct BadVAddr(u32);
+
+impl BadVAddr {
+    /// Load a [BadVAddr] from the _BadVAddr_ register (`$12`)
+    pub fn load() -> Self {
+        let bad_v_addr = unsafe { _read_badvaddr() };
+
+        BadVAddr(bad_v_addr)
+    }
+}
 
 bitflags! {
     /// The current processor state.

--- a/prussia_rt/src/routines.S
+++ b/prussia_rt/src/routines.S
@@ -25,6 +25,18 @@ _read_badvaddr:
 	jr $ra			# Return to Rust...
 	mfc0	$2, $8  # with the BadVAddr register value.
 
+# Read coprocessor 0 Count register.
+.global _read_timercount
+_read_timercount:
+	jr $ra			# Return to Rust...
+	mfc0	$2, $9  # with the Count register value.
+
+# Write coprocessor 0 Count register.
+.global _write_timercount
+_write_timercount:
+	jr	$ra			# Return to Rust...
+	mtc0	$4, $9	# after setting the Count register.
+
 # Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom
 # half. This method is always correct though.
 # $4 (a0) = address.

--- a/prussia_rt/src/routines.S
+++ b/prussia_rt/src/routines.S
@@ -49,6 +49,18 @@ _write_compare:
 	mtc0	$4, $11
 	jr	$ra
 
+# Read coprocessor 0 EPC register.
+.global _read_epc
+_read_epc:
+	mfc0	$2, $14
+	jr $ra
+
+# Write coprocessor 0 EPC register.
+.global _write_epc
+_write_epc:
+	mtc0	$4, $14
+	jr	$ra
+
 # Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom
 # half. This method is always correct though.
 # $4 (a0) = address.

--- a/prussia_rt/src/routines.S
+++ b/prussia_rt/src/routines.S
@@ -89,6 +89,18 @@ _write_errorepc:
 	jr	$ra
 	mtc0	$4, $30
 
+# Read coprocessor 0 PCCR register.
+.global _read_pccr
+_read_pccr:
+	jr $ra
+	mfps	$2, 0
+
+# Write coprocessor 0 PCCR register.
+.global _write_pccr
+_write_pccr:
+	jr $ra
+	mtps	$4, 0
+
 # Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom
 # half. This method is always correct though.
 # $4 (a0) = address.

--- a/prussia_rt/src/routines.S
+++ b/prussia_rt/src/routines.S
@@ -1,3 +1,7 @@
+# The assembler tries to reorder our instructions around delay slots.
+# Since we want to preserve this order, disable the reordering feature.
+.set noreorder
+
 # Bootstrap routine for PruSSia. LLVM only needs a stack pointer, and the rest we can do in Rust.
 .extern _rust_start
 .global _start
@@ -22,56 +26,56 @@ _write_status:
 # Read coprocessor 0 BadVAddr register.
 .global _read_badvaddr
 _read_badvaddr:
-	mfc0	$2, $8
 	jr $ra
+	mfc0	$2, $8
 
 # Read coprocessor 0 Count register.
 .global _read_timercount
 _read_timercount:
-	mfc0	$2, $9
 	jr $ra
+	mfc0	$2, $9
 
 # Write coprocessor 0 Count register.
 .global _write_timercount
 _write_timercount:
-	mtc0	$4, $9
 	jr	$ra
+	mtc0	$4, $9
 
 # Read coprocessor 0 Compare register.
 .global _read_compare
 _read_compare:
-	mfc0	$2, $11
 	jr $ra
+	mfc0	$2, $11
 
 # Write coprocessor 0 Compare register.
 .global _write_compare
 _write_compare:
-	mtc0	$4, $11
 	jr	$ra
+	mtc0	$4, $11
 
 # Read coprocessor 0 EPC register.
 .global _read_epc
 _read_epc:
-	mfc0	$2, $14
 	jr $ra
+	mfc0	$2, $14
 
 # Write coprocessor 0 EPC register.
 .global _write_epc
 _write_epc:
-	mtc0	$4, $14
 	jr	$ra
+	mtc0	$4, $14
 
 # Read coprocessor 0 BadPAddr register.
 .global _read_badpaddr
 _read_badpaddr:
-	mfc0	$2, $23
 	jr $ra
+	mfc0	$2, $23
 
 # Write coprocessor 0 BadPAddr register.
 .global _write_badpaddr
 _write_badpaddr:
-	mtc0	$4, $23
 	jr	$ra
+	mtc0	$4, $23
 
 # Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom
 # half. This method is always correct though.

--- a/prussia_rt/src/routines.S
+++ b/prussia_rt/src/routines.S
@@ -61,6 +61,18 @@ _write_epc:
 	mtc0	$4, $14
 	jr	$ra
 
+# Read coprocessor 0 BadPAddr register.
+.global _read_badpaddr
+_read_badpaddr:
+	mfc0	$2, $23
+	jr $ra
+
+# Write coprocessor 0 BadPAddr register.
+.global _write_badpaddr
+_write_badpaddr:
+	mtc0	$4, $23
+	jr	$ra
+
 # Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom
 # half. This method is always correct though.
 # $4 (a0) = address.

--- a/prussia_rt/src/routines.S
+++ b/prussia_rt/src/routines.S
@@ -19,7 +19,13 @@ _write_status:
 	jr	$ra			# Return to Rust...
 	mtc0	$4, $12			# after setting the Status register.
 
-# Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom 
+# Read coprocessor 0 BadVAddr register.
+.global _read_badvaddr
+_read_badvaddr:
+	jr $ra			# Return to Rust...
+	mfc0	$2, $8  # with the BadVAddr register value.
+
+# Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom
 # half. This method is always correct though.
 # $4 (a0) = address.
 .global _read_u64
@@ -32,7 +38,7 @@ _read_u64:
 	dsrl32	$3, 0			# Return highest word in $v1.
 	jr	$ra			# And return to caller.
 	nop
-	
+
 # Write a u64 atomically. Rust would make two writes, but this would probably confuse the device
 # we are writing to. This method is always correct though.
 # $4 (a0) = address.

--- a/prussia_rt/src/routines.S
+++ b/prussia_rt/src/routines.S
@@ -22,20 +22,32 @@ _write_status:
 # Read coprocessor 0 BadVAddr register.
 .global _read_badvaddr
 _read_badvaddr:
-	jr $ra			# Return to Rust...
-	mfc0	$2, $8  # with the BadVAddr register value.
+	mfc0	$2, $8
+	jr $ra
 
 # Read coprocessor 0 Count register.
 .global _read_timercount
 _read_timercount:
-	jr $ra			# Return to Rust...
-	mfc0	$2, $9  # with the Count register value.
+	mfc0	$2, $9
+	jr $ra
 
 # Write coprocessor 0 Count register.
 .global _write_timercount
 _write_timercount:
-	jr	$ra			# Return to Rust...
-	mtc0	$4, $9	# after setting the Count register.
+	mtc0	$4, $9
+	jr	$ra
+
+# Read coprocessor 0 Compare register.
+.global _read_compare
+_read_compare:
+	mfc0	$2, $11
+	jr $ra
+
+# Write coprocessor 0 Compare register.
+.global _write_compare
+_write_compare:
+	mtc0	$4, $11
+	jr	$ra
 
 # Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom
 # half. This method is always correct though.

--- a/prussia_rt/src/routines.S
+++ b/prussia_rt/src/routines.S
@@ -89,17 +89,42 @@ _write_errorepc:
 	jr	$ra
 	mtc0	$4, $30
 
-# Read coprocessor 0 PCCR register.
+# Read coprocessor 0 Perf/PCCR register.
 .global _read_pccr
 _read_pccr:
 	jr $ra
 	mfps	$2, 0
 
-# Write coprocessor 0 PCCR register.
+# Write coprocessor 0 Perf/PCCR register.
 .global _write_pccr
 _write_pccr:
 	jr $ra
 	mtps	$4, 0
+
+# Read coprocessor 0 PCR0 register.
+.global _read_pcr0
+_read_pcr0:
+	jr $ra
+	mfpc	$2, 0
+
+# Write coprocessor 0 PCR0 register.
+.global _write_pcr0
+_write_pcr0:
+	jr $ra
+	mtpc	$4, 0
+
+# Read coprocessor 1 PCR1 register.
+.global _read_pcr1
+_read_pcr1:
+	jr $ra
+	mfpc	$2, 1
+
+# Write coprocessor 1 PCR1 register.
+.global _write_pcr1
+_write_pcr1:
+	jr $ra
+	mtpc	$4, 1
+
 
 # Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom
 # half. This method is always correct though.

--- a/prussia_rt/src/routines.S
+++ b/prussia_rt/src/routines.S
@@ -77,6 +77,18 @@ _write_badpaddr:
 	jr	$ra
 	mtc0	$4, $23
 
+# Read coprocessor 0 ErrorEPC register.
+.global _read_errorepc
+_read_errorepc:
+	jr $ra
+	mfc0	$2, $30
+
+# Write coprocessor 0 ErrorEPC register.
+.global _write_errorepc
+_write_errorepc:
+	jr	$ra
+	mtc0	$4, $30
+
 # Read a u64 atomically. Rust would make two reads, but this would just be the truncated bottom
 # half. This method is always correct though.
 # $4 (a0) = address.


### PR DESCRIPTION
* This addresses issue #18.
* Add all exception-related CoP0 registers to the CoP0 routines in `prussia_rt/src/routines.S`.
* Add auto-reassembling of `prussia_rt/src/routines.S` if it's changed since recompilation.